### PR TITLE
fix bug stream::fin()

### DIFF
--- a/asdctool/src/main/java/org/openecomp/sdc/asdctool/migration/tasks/handlers/XlsOutputHandler.java
+++ b/asdctool/src/main/java/org/openecomp/sdc/asdctool/migration/tasks/handlers/XlsOutputHandler.java
@@ -100,7 +100,7 @@ public class XlsOutputHandler implements OutputHandler {
         if (StringUtils.isNotEmpty(outputPath)) {
             fileName.append(outputPath);
         }
-        return fileName.append(sheetName).append("_").append(new SimpleDateFormat("yyyyMMdd_HHmmss").format(System.currentTimeMillis()))
+        return fileName.append(sheetName).append("_").append(new SimpleDateFormat("yyyyMMdd_HHmmssZ").format(System.currentTimeMillis()))
             .append(".xls").toString();
     }
 }

--- a/catalog-model/src/main/java/org/openecomp/sdc/be/model/jsonjanusgraph/operations/ToscaElementOperation.java
+++ b/catalog-model/src/main/java/org/openecomp/sdc/be/model/jsonjanusgraph/operations/ToscaElementOperation.java
@@ -1379,7 +1379,7 @@ public abstract class ToscaElementOperation extends BaseOperation {
         if (resourceTypeStr != null) {
             ResourceTypeEnum resourceType = ResourceTypeEnum.getType((String) resourceTypeStr);
             if (!CollectionUtils.isEmpty(excludeTypes)) {
-                isAddToCatalog = not (excludeTypes.stream().anyMatch(rt -> rt == resourceType);
+                isAddToCatalog = not (excludeTypes.stream().anyMatch(rt -> rt == resourceType));
             }
         }
         return isAddToCatalog;

--- a/catalog-model/src/main/java/org/openecomp/sdc/be/model/jsonjanusgraph/operations/ToscaElementOperation.java
+++ b/catalog-model/src/main/java/org/openecomp/sdc/be/model/jsonjanusgraph/operations/ToscaElementOperation.java
@@ -1379,10 +1379,7 @@ public abstract class ToscaElementOperation extends BaseOperation {
         if (resourceTypeStr != null) {
             ResourceTypeEnum resourceType = ResourceTypeEnum.getType((String) resourceTypeStr);
             if (!CollectionUtils.isEmpty(excludeTypes)) {
-                Optional<ResourceTypeEnum> op = excludeTypes.stream().filter(rt -> rt == resourceType).findAny();
-                if (op.isPresent()) {
-                    isAddToCatalog = false;
-                }
+                isAddToCatalog = not (excludeTypes.stream().anyMatch(rt -> rt == resourceType);
             }
         }
         return isAddToCatalog;


### PR DESCRIPTION
It is more convenient and readable to directly use Stream::anyMatch instead of Stream::filter, Stream::findAny, and Optional::isPresent when the matched data returned by Stream::findAny is not used anywhere else.